### PR TITLE
Big changes to prop system for generic props

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm dev:web:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,238 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+**Starting the development servers:**
+```bash
+# Web app (Next.js + React Three Fiber)
+pnpm dev:web
+
+# Backend server (Express)
+pnpm dev:server
+```
+
+**Building:**
+```bash
+# Web app
+pnpm -C apps/web build
+
+# Server
+pnpm -C apps/server build
+```
+
+**Running production:**
+```bash
+# Web app
+pnpm -C apps/web start
+
+# Server
+pnpm -C apps/server start
+```
+
+## Architecture Overview
+
+### Monorepo Structure
+- **apps/web**: Next.js 15 frontend with React Three Fiber for 3D rendering
+- **apps/server**: Express backend (minimal; primarily health checks)
+- **packages/shared**: Shared TypeScript types and utilities
+- Path aliases: `@/` → `apps/web/src/`, `@shared/` → `packages/shared/src/`
+
+### Core Systems
+
+#### 1. GLTF Prop System
+The codebase uses a **data-driven GLTF loading system** that automatically extracts surfaces and bounds from 3D models.
+
+**Key Components:**
+- `GLTFProp.tsx`: Generic component that loads GLTF models and registers surfaces/bounds
+- `surfaceAdapter.ts`: Extracts interactive 2D surfaces from named GLTF nodes
+- `DeskProp.tsx` / `MonitorProp.tsx`: Thin wrappers around GLTFProp with prop-specific config
+
+**GLTF Model Requirements:**
+- Models must contain named plane nodes (e.g., `DeskTopPlane`, `ScreenPlane`)
+- Surfaces are extracted by analyzing node geometry, computing U/V axes, normal, and extents
+- Props anchor to scene via bbox alignment (desk: center/max/center, monitor: center/min/center)
+
+**How It Works:**
+1. `GLTFProp` loads a model and finds nodes by name
+2. `extractSurfaceFromNode()` analyzes geometry to determine:
+   - U/V axes (two longest dimensions)
+   - Normal (shortest dimension, determines thickness)
+   - Origin point (depends on `normalSide` option: 'positive', 'negative', 'center')
+3. Surface metadata stored in `surfaceMetaStore`, bounds in `propBoundsStore`
+4. Anchor system translates/rotates the entire prop hierarchy to position it correctly
+
+#### 2. Layout Frame System (Camera-First Alignment)
+The **layout frame** is the single source of truth for all spatial relationships, built from desk surface metadata.
+
+**Flow:**
+```
+Desk GLTF loads → extractSurfaceFromNode() → buildLayoutFrame()
+   ↓
+layoutFrameStore: { up, right, forward, center, extents, bounds }
+   ↓
+useAutoLayout() orchestrates:
+   ├─ solveCamera(): Computes optimal yaw/pitch/dolly to frame desk+monitor
+   └─ solveMonitor(): Positions monitor relative to desk frame
+```
+
+**Key Files:**
+- `useAutoLayout.ts`: **500-line orchestrator** that recomputes layout when desk/monitor/scale/overrides change
+- `layoutFrameStore.ts`: Stores canonical desk axes and state (status, frame, camera target, monitor placement)
+- Derived axes are orthonormalized: `up = desk.normal`, `right = desk.uDir`, `forward = cross(right, up)`
+
+**Monitor Auto-Placement Logic:**
+1. **Vertical**: Lift monitor so lowest point clears desk surface by `MONITOR_CLEARANCE` (1.5mm)
+2. **Rotation**: Align monitor normal to face desk `forward` vector (yaw rotation around `up`)
+3. **Lateral/Depth**: Center monitor on desk, clamped by `EDGE_MARGIN` (12mm)
+4. Overrides (`layoutOverridesStore`) allow manual nudges via UI
+
+#### 3. State Management
+**Zustand Stores (Client-Side):**
+- `cameraSlice.ts`: Camera mode (desk/screen), yaw/pitch/dolly, clamping per mode
+- `surfaceMetaStore.ts`: Surface metadata (center, normal, uDir, vDir, extents)
+- `propBoundsStore.ts`: World-space axis-aligned bounding boxes per prop
+- `layoutFrameStore.ts`: Canonical desk frame + computed camera/monitor placement
+- `layoutOverridesStore.ts`: Manual adjustments (desk rotation, monitor lateral/depth)
+- `propScaleStore.ts`: Uniform scale per prop (0.6x–1.6x)
+
+**State Flow:**
+```
+GLTF loads → surfaceMetaStore + propBoundsStore
+    ↓
+useAutoLayout() reads meta/bounds → layoutFrameStore
+    ↓
+SceneRoot reads layoutFrameStore → applies transforms to props
+```
+
+#### 4. Camera System
+Two modes with distinct behavior and clamps:
+
+- **Desk mode**: Orbit around computed target (desk+monitor center), wide clamps
+  - Yaw: -45° to 45°, Pitch: -12° to 22°, Dolly: 2.7–4.8m
+- **Screen mode**: Tight orbit around monitor surface center
+  - Yaw: -18° to 18°, Pitch: -12° to 12°, Dolly: 1.0–2.2m
+
+**Controllers:**
+- `DeskViewController.tsx`: OrbitControls for desk mode
+- `ScreenViewController.tsx`: OrbitControls for screen mode
+- Click monitor → enter screen mode (via raycasting + `planeProject`)
+- Press Escape → return to desk mode
+
+#### 5. Validation System
+`useLayoutValidation.ts` runs checks on every layout change:
+
+- **Desk surface origin mismatch**: Warns if GLTF-derived top differs from registered surface origin
+- **Monitor penetration**: Errors if monitor base is below desk surface
+- **Face alignment**: Errors if monitor normal deviates >5° from desk forward
+- **Edge overflow**: Warns if monitor extends past desk bounds (lateral/depth)
+
+Warnings logged to console; extensible via `onReport` callback.
+
+### Important Constraints & Conventions
+
+#### Scaling System (Current Known Issue)
+**Status:** Desk scaling works; **monitor scaling is broken** (as of commit `0c48c7a`).
+
+**How Scaling Should Work:**
+1. User adjusts scale via `PropScaleControls` → updates `propScaleStore`
+2. `GLTFProp` applies scale to inner group hierarchy (preserves anchor point)
+3. `useAutoLayout` detects non-unit scale and computes `scaledBounds` from initial bounds
+4. Monitor placement uses `scaledBounds` to recalculate vertical lift + centering
+
+**Current Bug:**
+- Monitor scaling doesn't preserve foot anchor correctly
+- Foot-anchor logic (lines 437-442 in `useAutoLayout.ts`) may be overcomplicated
+- Next work planned: "detaching monitor, scaling, reattaching"
+
+#### Surface Extraction Options
+When registering surfaces via `GLTFProp`:
+- `normalSide: 'positive'` (default): Use top face (desk top)
+- `normalSide: 'negative'`: Use bottom face (desk underside)
+- `normalSide: 'center'`: Use mid-plane
+
+Example:
+```tsx
+<DeskProp
+  registerSurfaces={[{
+    id: 'desk',
+    kind: 'desk',
+    nodeName: 'DeskTopPlane',
+    options: { normalSide: 'positive' }
+  }]}
+/>
+```
+
+#### Adding New Props
+To add a new prop (keyboard, lamp, etc.):
+
+1. Create GLTF with named plane node for interactive surface (if applicable)
+2. Place model in `apps/web/public/models/`
+3. Create wrapper component extending `GLTFProp`:
+   ```tsx
+   export function KeyboardProp({ url, position, rotation, scale }) {
+     return (
+       <GLTFProp
+         url={url}
+         position={position}
+         rotation={rotation}
+         scale={scale}
+         anchor={{ type: 'bbox', align: { x: 'center', y: 'min', z: 'center' } }}
+         propId="keyboard1"
+         registerSurfaces={[/* if needed */]}
+       />
+     );
+   }
+   ```
+4. Extend `useAutoLayout()` to compute placement relative to layout frame
+5. Add to `PropId` union in `propBoundsStore.ts`
+
+### File Organization Patterns
+
+**State:**
+- `apps/web/src/state/` - Zustand stores for global state
+
+**Canvas/3D:**
+- `apps/web/src/canvas/props/` - GLTF loading and prop components
+- `apps/web/src/canvas/Cameras/` - Camera controllers
+- `apps/web/src/canvas/hooks/` - React hooks for surfaces, bounds, layout, validation
+- `apps/web/src/canvas/math/` - Vector/plane math utilities
+
+**UI:**
+- `apps/web/src/canvas/debugHud.tsx` - Toggleable debug overlay
+- `apps/web/src/canvas/LayoutControls.tsx` - Desk rotation + monitor nudge controls
+- `apps/web/src/canvas/PropScaleControls.tsx` - Scaling UI
+
+### Key Technical Details
+
+**Vector Math:**
+- All vectors stored as `[x, y, z]` tuples (Vec3 type)
+- Use `toVec3(tuple)` to convert to THREE.Vector3 for computation
+- Use `toTuple(vec)` to convert back for storage
+
+**Transform Hierarchy in GLTFProp:**
+```
+<group position={position} rotation={rotation}>         ← Prop transform
+  <group position={anchorTuple}>                        ← Translate to anchor
+    <group scale={scale}>                               ← Apply scale
+      <group position={negativeAnchorTuple}>            ← Translate back
+        <primitive object={scene} />                    ← GLTF scene
+```
+This ensures scaling happens around the anchor point.
+
+**Layout Recomputation:**
+`useAutoLayout()` runs when any of these change:
+- Desk/monitor surface metadata or bounds
+- Manual overrides (desk yaw, monitor lateral/depth)
+- Prop scale (X, Y, Z components)
+
+Comparisons use small epsilon (1e-4 to 1e-6) to avoid thrashing from floating-point drift.
+
+## Planning Documents
+
+The `docs/` folder contains implementation plans:
+- `Plan camera-first desk align.txt`: Detailed 6-step plan for layout system (already implemented)
+- `prop-alignment-plan.md`: High-level goals and proposed workflow
+
+These documents describe the implemented architecture and can guide future extensions.

--- a/apps/web/src/app/canvas/SceneRoot.tsx
+++ b/apps/web/src/app/canvas/SceneRoot.tsx
@@ -21,6 +21,7 @@ import PropScaleControls from "@/canvas/PropScaleControls";
 import GenericPropsLayer from "@/canvas/GenericPropsLayer";
 import GenericPropControls from "@/canvas/GenericPropControls";
 import GenericPropScaleBanner from "@/canvas/GenericPropScaleBanner";
+import { clearSelection } from "@/state/selectionStore";
 
 export default function SceneRoot() {
   const mode = useCamera((s) => s.mode);
@@ -121,6 +122,7 @@ export default function SceneRoot() {
           scene.fog = new THREE.Fog(bg, 6, 16);
         }}
         onPointerDown={onPointerDown}
+        onPointerMissed={() => clearSelection()}
       >
         <Suspense fallback={null}>
           <DeskProp url="/models/DeskTopPlane.glb" rotation={deskRotation} scale={deskScale} />

--- a/apps/web/src/app/canvas/SceneRoot.tsx
+++ b/apps/web/src/app/canvas/SceneRoot.tsx
@@ -18,6 +18,9 @@ import { useLayoutOverridesState } from "@/canvas/hooks/useLayoutOverrides";
 import { usePropScale } from "@/canvas/hooks/usePropScale";
 import LayoutControls from "@/canvas/LayoutControls";
 import PropScaleControls from "@/canvas/PropScaleControls";
+import GenericPropsLayer from "@/canvas/GenericPropsLayer";
+import GenericPropControls from "@/canvas/GenericPropControls";
+import GenericPropScaleBanner from "@/canvas/GenericPropScaleBanner";
 
 export default function SceneRoot() {
   const mode = useCamera((s) => s.mode);
@@ -95,6 +98,7 @@ export default function SceneRoot() {
     <div className="relative h-[70vh] min-h-[540px]">
       <DebugHud />
       <div className="pointer-events-none absolute right-4 top-4 z-20 flex flex-col items-end gap-2">
+        <GenericPropControls />
         <LayoutControls />
         <PropScaleControls />
       </div>
@@ -127,10 +131,13 @@ export default function SceneRoot() {
             scale={monitorScale}
           />
 
+          <GenericPropsLayer />
           <Surfaces />
           {mode.kind === "desk" ? <DeskViewController /> : <ScreenViewController />}
         </Suspense>
       </Canvas>
+
+      <GenericPropScaleBanner />
 
       {!surfacesReady && (
         <div className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-md bg-black/60 px-4 py-2 text-sm text-white">
@@ -140,8 +147,3 @@ export default function SceneRoot() {
     </div>
   );
 }
-
-
-
-
-

--- a/apps/web/src/app/canvas/SceneRoot.tsx
+++ b/apps/web/src/app/canvas/SceneRoot.tsx
@@ -15,7 +15,9 @@ import { DeskProp } from "@/canvas/props/DeskProp";
 import { MonitorProp } from "@/canvas/props/MonitorProp";
 import { useAutoLayout } from "@/canvas/hooks/useAutoLayout";
 import { useLayoutOverridesState } from "@/canvas/hooks/useLayoutOverrides";
+import { usePropScale } from "@/canvas/hooks/usePropScale";
 import LayoutControls from "@/canvas/LayoutControls";
+import PropScaleControls from "@/canvas/PropScaleControls";
 
 export default function SceneRoot() {
   const mode = useCamera((s) => s.mode);
@@ -30,10 +32,13 @@ export default function SceneRoot() {
   const deskRotation: [number, number, number] = [0, deskYawRad, 0];
   const monitorPlacement = layoutState.monitorPlacement;
 
+  const deskScale = usePropScale("desk");
+  const monitorScale = usePropScale("monitor1");
+
   const handleLayoutWarnings = useCallback((warnings: LayoutWarning[]) => {
     warnings.forEach((warning) => {
       const log = warning.severity === "error" ? console.error : console.warn;
-      log(`[layout] ${warning.id}: ${warning.message}`);
+      log('[layout] ' + warning.id + ': ' + warning.message);
     });
   }, []);
 
@@ -89,7 +94,10 @@ export default function SceneRoot() {
   return (
     <div className="relative h-[70vh] min-h-[540px]">
       <DebugHud />
-      <LayoutControls />
+      <div className="pointer-events-none absolute right-4 top-4 z-20 flex flex-col items-end gap-2">
+        <LayoutControls />
+        <PropScaleControls />
+      </div>
       <Canvas
         style={{ width: "100%", height: "100%" }}
         camera={{ position: [0, 1.35, 3.6], fov: 48 }}
@@ -111,11 +119,12 @@ export default function SceneRoot() {
         onPointerDown={onPointerDown}
       >
         <Suspense fallback={null}>
-          <DeskProp url="/models/DeskTopPlane.glb" rotation={deskRotation} />
+          <DeskProp url="/models/DeskTopPlane.glb" rotation={deskRotation} scale={deskScale} />
           <MonitorProp
             url="/models/monitor_processed.glb"
             position={monitorPosition}
             rotation={monitorRotation}
+            scale={monitorScale}
           />
 
           <Surfaces />
@@ -131,4 +140,8 @@ export default function SceneRoot() {
     </div>
   );
 }
+
+
+
+
 

--- a/apps/web/src/canvas/GenericPropControls.tsx
+++ b/apps/web/src/canvas/GenericPropControls.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useState } from 'react';
+
+import { PROP_CATALOG } from '@/data/propCatalog';
+import { spawnGenericProp } from '@/state/genericPropsStore';
+import { setSelection } from '@/state/selectionStore';
+
+const PANEL_CLASS = 'pointer-events-auto w-56 rounded-md bg-black/70 p-3 text-sm text-white shadow-lg';
+const BUTTON_CLASS = 'pointer-events-auto rounded-full bg-black/70 px-3 py-1 text-xs uppercase tracking-wide text-white shadow hover:bg-black/80';
+
+export default function GenericPropControls({ className = '' }: { className?: string } = {}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleSpawn = useCallback((catalogId: string) => {
+    const entry = PROP_CATALOG.find((item) => item.id === catalogId);
+    if (!entry) return;
+
+    const prop = spawnGenericProp({
+      catalogId: entry.id,
+      label: entry.label,
+      url: entry.url,
+      anchor: entry.anchor,
+    });
+
+    setSelection({ kind: 'generic', id: prop.id });
+    setIsOpen(false);
+  }, []);
+
+  const containerClass = ['pointer-events-none flex flex-col items-end gap-2', className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={containerClass}>
+      <button
+        type="button"
+        className={BUTTON_CLASS}
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        {isOpen ? 'Close Props' : 'Add Prop'}
+      </button>
+
+      {isOpen && (
+        <div className={PANEL_CLASS}>
+          <div className="text-xs uppercase tracking-wide text-white/70">Prop Catalog</div>
+          <div className="mt-2 flex flex-col gap-2">
+            {PROP_CATALOG.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                className="w-full rounded border border-white/30 px-2 py-1 text-left text-xs uppercase tracking-wide hover:bg-white/10"
+                onClick={() => handleSpawn(entry.id)}
+              >
+                {entry.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/canvas/GenericPropScaleBanner.tsx
+++ b/apps/web/src/canvas/GenericPropScaleBanner.tsx
@@ -1,0 +1,35 @@
+import { useCallback } from 'react';
+
+import { useGenericProp } from '@/canvas/hooks/useGenericProps';
+import { useSelection } from '@/canvas/hooks/useSelection';
+import { setGenericPropStatus } from '@/state/genericPropsStore';
+
+export default function GenericPropScaleBanner() {
+  const selection = useSelection();
+  const selectedId = selection && selection.kind === 'generic' ? selection.id : null;
+  const prop = useGenericProp(selectedId);
+
+  const handleDone = useCallback(() => {
+    if (!prop) return;
+    setGenericPropStatus(prop.id, 'dragging');
+  }, [prop]);
+
+  if (!prop || prop.status !== 'editing') {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none absolute left-1/2 bottom-6 z-20 -translate-x-1/2">
+      <div className="pointer-events-auto flex items-center gap-3 rounded-full bg-black/70 px-4 py-2 text-[11px] uppercase tracking-wide text-white shadow">
+        <span>Editing scale - Press Done to finish</span>
+        <button
+          type="button"
+          className="rounded-full bg-white/20 px-3 py-1 text-[10px] uppercase tracking-wide hover:bg-white/30"
+          onClick={handleDone}
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/canvas/GenericPropsLayer.tsx
+++ b/apps/web/src/canvas/GenericPropsLayer.tsx
@@ -1,0 +1,20 @@
+import { Fragment } from 'react';
+
+import { useGenericProps } from '@/canvas/hooks/useGenericProps';
+import { GenericPropInstance } from '@/canvas/props/GenericProp';
+
+export default function GenericPropsLayer() {
+  const props = useGenericProps();
+
+  if (props.length === 0) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      {props.map((prop) => (
+        <GenericPropInstance key={prop.id} prop={prop} />
+      ))}
+    </Fragment>
+  );
+}

--- a/apps/web/src/canvas/LayoutControls.tsx
+++ b/apps/web/src/canvas/LayoutControls.tsx
@@ -1,4 +1,4 @@
-﻿import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { PointerEvent as ReactPointerEvent, KeyboardEvent as ReactKeyboardEvent, ReactNode } from "react";
 
 import { rotateDesk, nudgeMonitor, resetLayoutOverrides } from "@/state/layoutOverridesStore";
@@ -107,12 +107,20 @@ function HoldButton({ onActivate, className, children, holdIntervalMs }: HoldBut
   );
 }
 
-export default function LayoutControls() {
+type LayoutControlsProps = {
+  className?: string;
+};
+
+export default function LayoutControls({ className = "" }: LayoutControlsProps = {}) {
   const overrides = useLayoutOverridesState();
   const [isOpen, setIsOpen] = useState(false);
 
+  const containerClass = ["pointer-events-none flex flex-col items-end gap-2", className]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div className="pointer-events-none absolute right-4 top-4 z-20 flex flex-col items-end gap-2">
+    <div className={containerClass}>
       <button
         type="button"
         className="pointer-events-auto rounded-full bg-black/70 px-3 py-1 text-xs uppercase tracking-wide text-white shadow hover:bg-black/80"

--- a/apps/web/src/canvas/PropScaleControls.tsx
+++ b/apps/web/src/canvas/PropScaleControls.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useCamera } from '@/state/cameraSlice';
+import { setUniformPropScale } from '@/state/propScaleStore';
+import { usePropScale } from '@/canvas/hooks/usePropScale';
+import type { PropId } from '@/state/propBoundsStore';
+
+const MIN_SCALE = 0.6;
+const MAX_SCALE = 1.6;
+const STEP = 0.01;
+
+type PropScaleControlsProps = {
+  className?: string;
+};
+
+function describeProp(id: PropId) {
+  if (id === 'monitor1') {
+    return { label: 'Monitor', description: 'Primary display' };
+  }
+  return { label: 'Desk', description: 'Workspace surface' };
+}
+
+export default function PropScaleControls({ className = '' }: PropScaleControlsProps = {}) {
+  const mode = useCamera((s) => s.mode);
+  const activeId: PropId = mode.kind === 'screen' ? 'monitor1' : 'desk';
+  const activeInfo = useMemo(() => describeProp(activeId), [activeId]);
+
+  const scaleVec = usePropScale(activeId);
+  const uniformScale = useMemo(() => scaleVec[0], [scaleVec]);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [pendingValue, setPendingValue] = useState(uniformScale);
+
+  useEffect(() => {
+    setPendingValue(uniformScale);
+  }, [uniformScale, activeId]);
+
+  const handleScaleChange = useCallback(
+    (next: number) => {
+      setPendingValue(next);
+      setUniformPropScale(activeId, Number(next.toFixed(3)));
+    },
+    [activeId],
+  );
+
+  const handleReset = useCallback(() => {
+    setUniformPropScale(activeId, 1);
+  }, [activeId]);
+
+  const toggleOpen = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  const containerClass = ['pointer-events-none flex flex-col items-end gap-2', className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={containerClass}>
+      <button
+        type="button"
+        className="pointer-events-auto rounded-full bg-black/70 px-3 py-1 text-xs uppercase tracking-wide text-white shadow hover:bg-black/80"
+        onClick={toggleOpen}
+      >
+        {isOpen ? 'Hide Scale' : `Scale: ${activeInfo.label}`}
+      </button>
+
+      {isOpen && (
+        <div className="pointer-events-auto w-60 rounded-md bg-black/70 p-3 text-sm text-white shadow-lg">
+          <div className="text-xs uppercase tracking-wide text-white/70">Adjusting</div>
+          <div className="mt-1 font-semibold">{activeInfo.label}</div>
+          <div className="text-xs text-white/60">{activeInfo.description}</div>
+
+          <div className="mt-4">
+            <div className="flex items-center justify-between text-xs uppercase tracking-wide text-white/70">
+              <span>Scale</span>
+              <span>{pendingValue.toFixed(2)}x</span>
+            </div>
+            <input
+              type="range"
+              min={MIN_SCALE}
+              max={MAX_SCALE}
+              step={STEP}
+              value={pendingValue}
+              onChange={(event) => handleScaleChange(Number(event.target.value))}
+              className="mt-2 w-full"
+            />
+            <div className="mt-2 flex items-center justify-between text-[11px] text-white/60">
+              <span>{MIN_SCALE.toFixed(1)}x</span>
+              <button
+                type="button"
+                className="rounded border border-white/30 px-2 py-1 text-[10px] uppercase tracking-wide hover:bg-white/10"
+                onClick={handleReset}
+              >
+                Reset
+              </button>
+              <span>{MAX_SCALE.toFixed(1)}x</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/canvas/PropScaleControls.tsx
+++ b/apps/web/src/canvas/PropScaleControls.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useCamera } from '@/state/cameraSlice';
 import { setUniformPropScale } from '@/state/propScaleStore';
@@ -37,6 +37,7 @@ type GenericTarget = {
   label: string;
   description: string;
   scale: number;
+  status: 'editing' | 'dragging' | 'placed';
 };
 
 type ScaleTarget = FixedTarget | GenericTarget;
@@ -69,6 +70,7 @@ export default function PropScaleControls({ className = '' }: PropScaleControlsP
       label: selectedGeneric.label ?? 'Prop',
       description: selectedGeneric.label ? `${selectedGeneric.label} (Generic)` : 'Generic prop',
       scale: selectedGeneric.scale[0],
+      status: selectedGeneric.status,
     };
   }, [selectedGeneric]);
 
@@ -81,6 +83,21 @@ export default function PropScaleControls({ className = '' }: PropScaleControlsP
   useEffect(() => {
     setPendingValue(target.scale);
   }, [target.scale, targetKey]);
+
+  const prevGenericStatusRef = useRef<'editing' | 'dragging' | 'placed' | null>(null);
+
+  useEffect(() => {
+    if (!genericTarget) {
+      prevGenericStatusRef.current = null;
+      return;
+    }
+
+    if (genericTarget.status === 'editing' && prevGenericStatusRef.current !== 'editing') {
+      setIsOpen(true);
+    }
+
+    prevGenericStatusRef.current = genericTarget.status;
+  }, [genericTarget]);
 
   const handleScaleChange = useCallback(
     (next: number) => {
@@ -158,3 +175,5 @@ export default function PropScaleControls({ className = '' }: PropScaleControlsP
     </div>
   );
 }
+
+

--- a/apps/web/src/canvas/PropScaleControls.tsx
+++ b/apps/web/src/canvas/PropScaleControls.tsx
@@ -96,6 +96,10 @@ export default function PropScaleControls({ className = '' }: PropScaleControlsP
       setIsOpen(true);
     }
 
+    if (genericTarget.status !== 'editing' && prevGenericStatusRef.current === 'editing') {
+      setIsOpen(false);
+    }
+
     prevGenericStatusRef.current = genericTarget.status;
   }, [genericTarget]);
 

--- a/apps/web/src/canvas/PropScaleControls.tsx
+++ b/apps/web/src/canvas/PropScaleControls.tsx
@@ -37,7 +37,6 @@ type GenericTarget = {
   label: string;
   description: string;
   scale: number;
-  status: string;
 };
 
 type ScaleTarget = FixedTarget | GenericTarget;
@@ -70,7 +69,6 @@ export default function PropScaleControls({ className = '' }: PropScaleControlsP
       label: selectedGeneric.label ?? 'Prop',
       description: selectedGeneric.label ? `${selectedGeneric.label} (Generic)` : 'Generic prop',
       scale: selectedGeneric.scale[0],
-      status: selectedGeneric.status,
     };
   }, [selectedGeneric]);
 
@@ -113,8 +111,6 @@ export default function PropScaleControls({ className = '' }: PropScaleControlsP
     .filter(Boolean)
     .join(' ');
 
-  const isDisabled = target.type === 'generic' && target.status !== 'editing';
-
   return (
     <div className={containerClass}>
       <button
@@ -144,25 +140,18 @@ export default function PropScaleControls({ className = '' }: PropScaleControlsP
               value={pendingValue}
               onChange={(event) => handleScaleChange(Number(event.target.value))}
               className="mt-2 w-full"
-              disabled={isDisabled}
             />
             <div className="mt-2 flex items-center justify-between text-[11px] text-white/60">
               <span>{MIN_SCALE.toFixed(1)}x</span>
               <button
                 type="button"
-                className="rounded border border-white/30 px-2 py-1 text-[10px] uppercase tracking-wide hover:bg-white/10 disabled:opacity-40"
+                className="rounded border border-white/30 px-2 py-1 text-[10px] uppercase tracking-wide hover:bg-white/10"
                 onClick={handleReset}
-                disabled={isDisabled}
               >
                 Reset
               </button>
               <span>{MAX_SCALE.toFixed(1)}x</span>
             </div>
-            {isDisabled && (
-              <div className="mt-2 rounded bg-white/10 px-2 py-1 text-[10px] uppercase tracking-wide text-white/70">
-                Exit editing mode to adjust scale
-              </div>
-            )}
           </div>
         </div>
       )}

--- a/apps/web/src/canvas/hooks/useGenericProps.ts
+++ b/apps/web/src/canvas/hooks/useGenericProps.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from 'react';
+
+import {
+  getGenericProp,
+  getGenericPropsSnapshot,
+  subscribeGenericProps,
+  type GenericProp,
+  type GenericPropId,
+} from '@/state/genericPropsStore';
+
+const getServerSnapshot = () => getGenericPropsSnapshot();
+
+export function useGenericProps(): GenericProp[] {
+  return useSyncExternalStore(subscribeGenericProps, getGenericPropsSnapshot, getServerSnapshot);
+}
+
+export function useGenericProp(id: GenericPropId | null | undefined): GenericProp | null {
+  return useSyncExternalStore(
+    subscribeGenericProps,
+    () => (id ? getGenericProp(id) ?? null : null),
+    () => {
+      if (!id) return null;
+      const snapshot = getServerSnapshot();
+      return snapshot.find((prop) => prop.id === id) ?? null;
+    },
+  );
+}

--- a/apps/web/src/canvas/hooks/usePropScale.ts
+++ b/apps/web/src/canvas/hooks/usePropScale.ts
@@ -1,0 +1,23 @@
+import { useSyncExternalStore } from 'react';
+
+import {
+  getPropScale,
+  getPropScaleState,
+  subscribePropScale,
+  type PropScaleValue,
+} from '@/state/propScaleStore';
+import type { PropId } from '@/state/propBoundsStore';
+
+const getServerSnapshot = (() => {
+  const snapshot = getPropScaleState();
+  return (id: PropId) => snapshot[id];
+})();
+
+export function usePropScale(id: PropId): PropScaleValue {
+  return useSyncExternalStore(
+    subscribePropScale,
+    () => getPropScale(id),
+    () => getServerSnapshot(id),
+  );
+}
+

--- a/apps/web/src/canvas/hooks/useSelection.ts
+++ b/apps/web/src/canvas/hooks/useSelection.ts
@@ -1,0 +1,9 @@
+import { useSyncExternalStore } from 'react';
+
+import { getSelection, subscribeSelection, type Selection } from '@/state/selectionStore';
+
+const getServerSnapshot = () => getSelection();
+
+export function useSelection(): Selection {
+  return useSyncExternalStore(subscribeSelection, getSelection, getServerSnapshot);
+}

--- a/apps/web/src/canvas/props/DeskProp.tsx
+++ b/apps/web/src/canvas/props/DeskProp.tsx
@@ -1,4 +1,4 @@
-﻿import GLTFProp from './GLTFProp';
+import GLTFProp from './GLTFProp';
 
 type DeskPropProps = {
   url: string;
@@ -14,9 +14,11 @@ export function DeskProp({ url, position, rotation, scale }: DeskPropProps) {
       position={position}
       rotation={rotation}
       scale={scale}
+      anchor={{ type: 'bbox', align: { x: 'center', y: 'max', z: 'center' } }}
       propId="desk"
       registerSurfaces={[{ id: 'desk', kind: 'desk', nodeName: 'DeskTopPlane', options: { normalSide: 'positive' } }]}
     />
   );
 }
+
 

--- a/apps/web/src/canvas/props/GLTFProp.tsx
+++ b/apps/web/src/canvas/props/GLTFProp.tsx
@@ -16,15 +16,70 @@ type SurfaceReg = {
   onExtract?: (info: ReturnType<typeof extractSurfaceFromNode>['debug']) => void;
 };
 
+type AnchorAxis = 'min' | 'center' | 'max';
+
+type VectorAnchor = {
+  type: 'vector';
+  value: [number, number, number];
+};
+
+type BoundingBoxAnchor = {
+  type: 'bbox';
+  align: {
+    x: AnchorAxis;
+    y: AnchorAxis;
+    z: AnchorAxis;
+  };
+  offset?: [number, number, number];
+};
+
+export type AnchorConfig = VectorAnchor | BoundingBoxAnchor;
+
 type Props = {
   url: string;
   registerSurfaces?: SurfaceReg[];
   position?: [number, number, number];
   rotation?: [number, number, number];
   scale?: number | [number, number, number];
+  anchor?: AnchorConfig;
   onLoaded?: (root: THREE.Object3D, nodes: Record<string, THREE.Object3D>) => void;
   propId?: PropId;
 };
+
+function pickAxisValue(bounds: THREE.Box3, axis: 'x' | 'y' | 'z', mode: AnchorAxis) {
+  const min = bounds.min[axis];
+  const max = bounds.max[axis];
+  if (mode === 'min') return min;
+  if (mode === 'max') return max;
+  return (min + max) / 2;
+}
+
+function computeAnchor(scene: THREE.Object3D, config?: AnchorConfig): THREE.Vector3 | null {
+  if (!config) return null;
+
+  if (config.type === 'vector') {
+    const [x, y, z] = config.value;
+    return new THREE.Vector3(x, y, z);
+  }
+
+  scene.updateMatrixWorld(true);
+  const bounds = new THREE.Box3().setFromObject(scene);
+  if (bounds.isEmpty()) {
+    return new THREE.Vector3(0, 0, 0);
+  }
+
+  const anchor = new THREE.Vector3(
+    pickAxisValue(bounds, 'x', config.align.x),
+    pickAxisValue(bounds, 'y', config.align.y),
+    pickAxisValue(bounds, 'z', config.align.z),
+  );
+
+  if (config.offset) {
+    anchor.add(new THREE.Vector3(config.offset[0], config.offset[1], config.offset[2]));
+  }
+
+  return anchor;
+}
 
 export default function GLTFProp({
   url,
@@ -32,12 +87,23 @@ export default function GLTFProp({
   position,
   rotation,
   scale,
+  anchor,
   onLoaded,
   propId,
 }: Props) {
   const { scene } = useGLTF(url);
   const groupRef = React.useRef<THREE.Group>(null);
   const didNotifyLoaded = React.useRef(false);
+
+  const anchorVector = React.useMemo(() => computeAnchor(scene, anchor), [scene, anchor]);
+  const anchorTuple = React.useMemo<[number, number, number]>(() => {
+    if (!anchorVector) return [0, 0, 0];
+    return [anchorVector.x, anchorVector.y, anchorVector.z];
+  }, [anchorVector]);
+  const negativeAnchorTuple = React.useMemo<[number, number, number]>(
+    () => [-anchorTuple[0], -anchorTuple[1], -anchorTuple[2]],
+    [anchorTuple],
+  );
 
   const nodes = React.useMemo(() => {
     const map: Record<string, THREE.Object3D> = {};
@@ -113,7 +179,7 @@ export default function GLTFProp({
     if (bounds.isEmpty()) return;
 
     setPropBounds(propId, { min: toVec3(bounds.min), max: toVec3(bounds.max) });
-  }, [propId, scene.uuid, position, rotation, scale]);
+  }, [propId, scene.uuid, position, rotation, scale, anchorTuple]);
 
   React.useEffect(() => {
     if (!propId) return;
@@ -122,9 +188,17 @@ export default function GLTFProp({
     };
   }, [propId]);
 
+  const appliedScale = scale ?? 1;
+
   return (
-    <group ref={groupRef} position={position} rotation={rotation} scale={scale}>
-      <primitive object={scene} />
+    <group ref={groupRef} position={position} rotation={rotation}>
+      <group position={anchorTuple}>
+        <group scale={appliedScale}>
+          <group position={negativeAnchorTuple}>
+            <primitive object={scene} />
+          </group>
+        </group>
+      </group>
     </group>
   );
 }

--- a/apps/web/src/canvas/props/GenericProp.tsx
+++ b/apps/web/src/canvas/props/GenericProp.tsx
@@ -1,21 +1,35 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 
 import GLTFProp from './GLTFProp';
 import {
   clearGenericPropBounds,
   setGenericPropBounds,
+  setGenericPropPosition,
   type GenericProp,
 } from '@/state/genericPropsStore';
 import { setSelection } from '@/state/selectionStore';
+import { useSurface } from '@/canvas/hooks/useSurfaces';
+import { planeProject } from '@/canvas/math/plane';
 
 const DEFAULT_ANCHOR = { type: 'bbox', align: { x: 'center', y: 'min', z: 'center' } } as const;
+
+const WORLD_UP = new THREE.Vector3(0, 1, 0);
+const TMP_PLANE = new THREE.Plane();
+const TMP_POINT = new THREE.Vector3();
 
 type GenericPropInstanceProps = {
   prop: GenericProp;
 };
 
 export function GenericPropInstance({ prop }: GenericPropInstanceProps) {
+  const deskSurface = useSurface('desk');
+
+  const dragActiveRef = useRef(false);
+  const pointerIdRef = useRef<number | null>(null);
+  const grabOffsetRef = useRef(new THREE.Vector3());
+
   useEffect(() => {
     return () => {
       clearGenericPropBounds(prop.id);
@@ -29,12 +43,73 @@ export function GenericPropInstance({ prop }: GenericPropInstanceProps) {
     [prop.id],
   );
 
+  const computeIntersection = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      const ray = event.ray;
+
+      if (deskSurface) {
+        const hit = planeProject(ray, deskSurface);
+        if (hit.hit) {
+          return hit.point.clone();
+        }
+      }
+
+      const fallbackY = deskSurface ? deskSurface.origin[1] : prop.position[1];
+      TMP_PLANE.set(WORLD_UP, -fallbackY);
+      const worldPoint = ray.intersectPlane(TMP_PLANE, TMP_POINT);
+      return worldPoint ? worldPoint.clone() : null;
+    },
+    [deskSurface, prop.position],
+  );
+
   const handlePointerDown = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
       event.stopPropagation();
+      event.nativeEvent.stopImmediatePropagation?.();
       setSelection({ kind: 'generic', id: prop.id });
+
+      if (prop.status !== 'dragging') {
+        return;
+      }
+
+      const intersection = computeIntersection(event);
+      if (!intersection) {
+        return;
+      }
+
+      dragActiveRef.current = true;
+      pointerIdRef.current = event.pointerId;
+      grabOffsetRef.current.set(prop.position[0], prop.position[1], prop.position[2]).sub(intersection);
+
+      event.target.setPointerCapture?.(event.pointerId);
     },
-    [prop.id],
+    [computeIntersection, prop.id, prop.position, prop.status],
+  );
+
+  const finishDrag = useCallback((event: ThreeEvent<PointerEvent>) => {
+    if (!dragActiveRef.current) return;
+    if (pointerIdRef.current !== null && pointerIdRef.current !== event.pointerId) return;
+
+    dragActiveRef.current = false;
+    pointerIdRef.current = null;
+
+    event.target.releasePointerCapture?.(event.pointerId);
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      if (!dragActiveRef.current) return;
+      if (pointerIdRef.current !== null && pointerIdRef.current !== event.pointerId) return;
+
+      const intersection = computeIntersection(event);
+      if (!intersection) {
+        return;
+      }
+
+      const next = intersection.add(grabOffsetRef.current);
+      setGenericPropPosition(prop.id, [next.x, next.y, next.z]);
+    },
+    [computeIntersection, prop.id],
   );
 
   return (
@@ -47,6 +122,10 @@ export function GenericPropInstance({ prop }: GenericPropInstanceProps) {
       onBoundsChanged={handleBoundsChanged}
       groupProps={{
         onPointerDown: handlePointerDown,
+        onPointerMove: handlePointerMove,
+        onPointerUp: finishDrag,
+        onPointerCancel: finishDrag,
+        onPointerLeave: finishDrag,
       }}
     />
   );

--- a/apps/web/src/canvas/props/GenericProp.tsx
+++ b/apps/web/src/canvas/props/GenericProp.tsx
@@ -1,0 +1,53 @@
+import { useCallback, useEffect } from 'react';
+import type { ThreeEvent } from '@react-three/fiber';
+
+import GLTFProp from './GLTFProp';
+import {
+  clearGenericPropBounds,
+  setGenericPropBounds,
+  type GenericProp,
+} from '@/state/genericPropsStore';
+import { setSelection } from '@/state/selectionStore';
+
+const DEFAULT_ANCHOR = { type: 'bbox', align: { x: 'center', y: 'min', z: 'center' } } as const;
+
+type GenericPropInstanceProps = {
+  prop: GenericProp;
+};
+
+export function GenericPropInstance({ prop }: GenericPropInstanceProps) {
+  useEffect(() => {
+    return () => {
+      clearGenericPropBounds(prop.id);
+    };
+  }, [prop.id]);
+
+  const handleBoundsChanged = useCallback(
+    (bounds: { min: [number, number, number]; max: [number, number, number] }) => {
+      setGenericPropBounds(prop.id, bounds);
+    },
+    [prop.id],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      event.stopPropagation();
+      setSelection({ kind: 'generic', id: prop.id });
+    },
+    [prop.id],
+  );
+
+  return (
+    <GLTFProp
+      url={prop.url}
+      position={prop.position}
+      rotation={prop.rotation}
+      scale={prop.scale}
+      anchor={prop.anchor ?? DEFAULT_ANCHOR}
+      onBoundsChanged={handleBoundsChanged}
+      groupProps={{
+        onPointerDown: handlePointerDown,
+      }}
+    />
+  );
+}

--- a/apps/web/src/canvas/props/GenericProp.tsx
+++ b/apps/web/src/canvas/props/GenericProp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 
@@ -7,17 +7,27 @@ import {
   clearGenericPropBounds,
   setGenericPropBounds,
   setGenericPropPosition,
+  setGenericPropStatus,
   type GenericProp,
 } from '@/state/genericPropsStore';
-import { setSelection } from '@/state/selectionStore';
+import { clearSelection, setSelection } from '@/state/selectionStore';
 import { useSurface } from '@/canvas/hooks/useSurfaces';
 import { planeProject } from '@/canvas/math/plane';
+import { lockCameraOrbit, unlockCameraOrbit } from '@/state/cameraInteractionStore';
+import { useSelection } from '@/canvas/hooks/useSelection';
 
 const DEFAULT_ANCHOR = { type: 'bbox', align: { x: 'center', y: 'min', z: 'center' } } as const;
 
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const TMP_PLANE = new THREE.Plane();
 const TMP_POINT = new THREE.Vector3();
+const TMP_RAY = new THREE.Ray();
+
+const HIGHLIGHT_COLOR = '#5eead4';
+const HIGHLIGHT_MINOR_RADIUS_SCALE = 0.55;
+const HIGHLIGHT_MAJOR_RADIUS_SCALE = 1.1;
+const DESK_CLEARANCE = 0.015;
+const CLEARANCE_EPSILON = 1e-4;
 
 type GenericPropInstanceProps = {
   prop: GenericProp;
@@ -25,6 +35,8 @@ type GenericPropInstanceProps = {
 
 export function GenericPropInstance({ prop }: GenericPropInstanceProps) {
   const deskSurface = useSurface('desk');
+  const selection = useSelection();
+  const isSelected = selection?.kind === 'generic' && selection.id === prop.id;
 
   const dragActiveRef = useRef(false);
   const pointerIdRef = useRef<number | null>(null);
@@ -35,6 +47,14 @@ export function GenericPropInstance({ prop }: GenericPropInstanceProps) {
       clearGenericPropBounds(prop.id);
     };
   }, [prop.id]);
+
+  const deskHeight = useMemo(() => {
+    if (!deskSurface) return null;
+    return deskSurface.origin[1];
+  }, [deskSurface]);
+
+  const propMinY = prop.bounds?.min[1] ?? null;
+  const currentPositionY = prop.position[1];
 
   const handleBoundsChanged = useCallback(
     (bounds: { min: [number, number, number]; max: [number, number, number] }) => {
@@ -62,18 +82,45 @@ export function GenericPropInstance({ prop }: GenericPropInstanceProps) {
     [deskSurface, prop.position],
   );
 
+  const constrainHeight = useCallback(
+    (next: THREE.Vector3) => {
+      if (deskHeight == null || propMinY == null) {
+        return next;
+      }
+      const desiredFoot = deskHeight + DESK_CLEARANCE;
+      const deltaY = next.y - currentPositionY;
+      const predictedMin = propMinY + deltaY;
+      if (predictedMin < desiredFoot) {
+        next.y += desiredFoot - predictedMin;
+      }
+      return next;
+    },
+    [deskHeight, propMinY, currentPositionY],
+  );
+
   const handlePointerDown = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
+      lockCameraOrbit();
       event.stopPropagation();
       event.nativeEvent.stopImmediatePropagation?.();
       setSelection({ kind: 'generic', id: prop.id });
 
-      if (prop.status !== 'dragging') {
+      let effectiveStatus = prop.status;
+      if (prop.status === 'placed') {
+        setGenericPropStatus(prop.id, 'dragging');
+        effectiveStatus = 'dragging';
+      }
+
+      if (effectiveStatus !== 'dragging') {
+        requestAnimationFrame(() => {
+          unlockCameraOrbit();
+        });
         return;
       }
 
       const intersection = computeIntersection(event);
       if (!intersection) {
+        unlockCameraOrbit();
         return;
       }
 
@@ -87,13 +134,20 @@ export function GenericPropInstance({ prop }: GenericPropInstanceProps) {
   );
 
   const finishDrag = useCallback((event: ThreeEvent<PointerEvent>) => {
-    if (!dragActiveRef.current) return;
+    if (!dragActiveRef.current) {
+      unlockCameraOrbit();
+      return;
+    }
     if (pointerIdRef.current !== null && pointerIdRef.current !== event.pointerId) return;
+
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation?.();
 
     dragActiveRef.current = false;
     pointerIdRef.current = null;
 
     event.target.releasePointerCapture?.(event.pointerId);
+    unlockCameraOrbit();
   }, []);
 
   const handlePointerMove = useCallback(
@@ -101,32 +155,113 @@ export function GenericPropInstance({ prop }: GenericPropInstanceProps) {
       if (!dragActiveRef.current) return;
       if (pointerIdRef.current !== null && pointerIdRef.current !== event.pointerId) return;
 
+      event.stopPropagation();
+      event.nativeEvent.stopImmediatePropagation?.();
+
       const intersection = computeIntersection(event);
       if (!intersection) {
         return;
       }
 
       const next = intersection.add(grabOffsetRef.current);
+      constrainHeight(next);
       setGenericPropPosition(prop.id, [next.x, next.y, next.z]);
     },
-    [computeIntersection, prop.id],
+    [computeIntersection, prop.id, constrainHeight],
   );
 
+  const isOverDesk = useMemo(() => {
+    if (!deskSurface) return false;
+    const rayOriginY = (prop.bounds?.max[1] ?? prop.position[1]) + 1;
+    TMP_RAY.origin.set(prop.position[0], rayOriginY, prop.position[2]);
+    TMP_RAY.direction.set(0, -1, 0);
+    const hit = planeProject(TMP_RAY, deskSurface);
+    if (!hit.hit) return false;
+    return hit.u >= 0 && hit.u <= 1 && hit.v >= 0 && hit.v <= 1;
+  }, [deskSurface, prop.bounds, prop.position]);
+
+  useEffect(() => {
+    if (!isSelected || prop.status !== 'dragging') return;
+
+    function handleKey(ev: KeyboardEvent) {
+      if (ev.key === 'Escape') {
+        dragActiveRef.current = false;
+        pointerIdRef.current = null;
+        setGenericPropStatus(prop.id, 'placed');
+        clearSelection();
+        unlockCameraOrbit();
+      }
+    }
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isSelected, prop.status, prop.id]);
+
+  useEffect(() => {
+    if (deskHeight == null) return;
+    if (!prop.bounds) return;
+    if (!isOverDesk) return;
+    if (prop.status === 'dragging' && dragActiveRef.current) return;
+
+    const desiredFoot = deskHeight + DESK_CLEARANCE;
+    const currentFoot = prop.bounds.min[1];
+    if (currentFoot >= desiredFoot - CLEARANCE_EPSILON) {
+      return;
+    }
+    const delta = desiredFoot - currentFoot;
+    const targetY = prop.position[1] + delta;
+    if (Math.abs(prop.position[1] - targetY) > CLEARANCE_EPSILON) {
+      setGenericPropPosition(prop.id, [prop.position[0], targetY, prop.position[2]]);
+    }
+  }, [deskHeight, propMinY, isOverDesk, prop.bounds, prop.id, prop.position, prop.status]);
+
+  const highlightData = useMemo(() => {
+    if (!prop.bounds) {
+      return {
+        center: [prop.position[0], prop.position[1], prop.position[2]] as [number, number, number],
+        minorRadius: 0.12,
+        majorRadius: 0.18,
+      };
+    }
+    const min = prop.bounds.min;
+    const max = prop.bounds.max;
+    const center: [number, number, number] = [
+      (min[0] + max[0]) / 2,
+      min[1] + 0.002,
+      (min[2] + max[2]) / 2,
+    ];
+    const sizeX = Math.max(Math.abs(max[0] - min[0]), 0.001);
+    const sizeZ = Math.max(Math.abs(max[2] - min[2]), 0.001);
+    const baseRadius = Math.max(sizeX, sizeZ) / 2;
+    const majorRadius = baseRadius === 0 ? 0.18 : baseRadius * HIGHLIGHT_MAJOR_RADIUS_SCALE;
+    const minorRadius = majorRadius * HIGHLIGHT_MINOR_RADIUS_SCALE;
+    return { center, minorRadius, majorRadius };
+  }, [prop.bounds, prop.position]);
+
   return (
-    <GLTFProp
-      url={prop.url}
-      position={prop.position}
-      rotation={prop.rotation}
-      scale={prop.scale}
-      anchor={prop.anchor ?? DEFAULT_ANCHOR}
-      onBoundsChanged={handleBoundsChanged}
-      groupProps={{
-        onPointerDown: handlePointerDown,
-        onPointerMove: handlePointerMove,
-        onPointerUp: finishDrag,
-        onPointerCancel: finishDrag,
-        onPointerLeave: finishDrag,
-      }}
-    />
+    <>
+      <GLTFProp
+        url={prop.url}
+        position={prop.position}
+        rotation={prop.rotation}
+        scale={prop.scale}
+        anchor={prop.anchor ?? DEFAULT_ANCHOR}
+        onBoundsChanged={handleBoundsChanged}
+        groupProps={{
+          onPointerDown: handlePointerDown,
+          onPointerMove: handlePointerMove,
+          onPointerUp: finishDrag,
+          onPointerCancel: finishDrag,
+          onPointerLeave: finishDrag,
+        }}
+      />
+      {isSelected && (
+        <mesh position={highlightData.center} rotation={[-Math.PI / 2, 0, 0]} raycast={() => null}>
+          <ringGeometry args={[highlightData.minorRadius, highlightData.majorRadius, 48]} />
+          <meshBasicMaterial color={HIGHLIGHT_COLOR} transparent opacity={0.4} />
+        </mesh>
+      )}
+    </>
   );
 }
+

--- a/apps/web/src/canvas/props/MonitorProp.tsx
+++ b/apps/web/src/canvas/props/MonitorProp.tsx
@@ -4,18 +4,23 @@ export function MonitorProp({
   url,
   position,
   rotation,
+  scale,
 }: {
   url: string;
   position?: [number, number, number];
   rotation?: [number, number, number];
+  scale?: number | [number, number, number];
 }) {
   return (
     <GLTFProp
       url={url}
       position={position}
       rotation={rotation}
+      scale={scale}
+      anchor={{ type: 'bbox', align: { x: 'center', y: 'min', z: 'center' } }}
       propId="monitor1"
       registerSurfaces={[{ id: 'monitor1', kind: 'monitor', nodeName: 'ScreenPlane' }]}
     />
   );
 }
+

--- a/apps/web/src/data/propCatalog.ts
+++ b/apps/web/src/data/propCatalog.ts
@@ -1,0 +1,17 @@
+import type { AnchorConfig } from '@/canvas/props/GLTFProp';
+
+export type PropCatalogEntry = {
+  id: string;
+  label: string;
+  url: string;
+  anchor?: AnchorConfig;
+};
+
+export const PROP_CATALOG: PropCatalogEntry[] = [
+  {
+    id: 'lamp-basic',
+    label: 'Desk Lamp',
+    url: '/models/lamp.glb',
+    anchor: { type: 'bbox', align: { x: 'center', y: 'min', z: 'center' } },
+  },
+];

--- a/apps/web/src/state/cameraInteractionStore.ts
+++ b/apps/web/src/state/cameraInteractionStore.ts
@@ -1,0 +1,29 @@
+let orbitLocked = false;
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach((listener) => listener());
+}
+
+export function lockCameraOrbit() {
+  if (!orbitLocked) {
+    orbitLocked = true;
+    emit();
+  }
+}
+
+export function unlockCameraOrbit() {
+  if (orbitLocked) {
+    orbitLocked = false;
+    emit();
+  }
+}
+
+export function isCameraOrbitLocked() {
+  return orbitLocked;
+}
+
+export function subscribeCameraOrbit(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/apps/web/src/state/genericPropsStore.ts
+++ b/apps/web/src/state/genericPropsStore.ts
@@ -1,0 +1,204 @@
+import type { AnchorConfig } from '@/canvas/props/GLTFProp';
+
+export type GenericPropId = string;
+export type GenericPropStatus = 'editing' | 'dragging' | 'placed';
+export type Vec3 = [number, number, number];
+
+export type GenericPropBounds = {
+  min: Vec3;
+  max: Vec3;
+};
+
+export type GenericProp = {
+  id: GenericPropId;
+  kind: 'generic';
+  catalogId?: string;
+  label?: string;
+  url: string;
+  anchor?: AnchorConfig;
+  position: Vec3;
+  rotation: Vec3;
+  scale: Vec3;
+  status: GenericPropStatus;
+  bounds?: GenericPropBounds;
+};
+
+type GenericPropBlueprint = {
+  catalogId: string;
+  label?: string;
+  url: string;
+  anchor?: AnchorConfig;
+  position?: Vec3;
+  rotation?: Vec3;
+};
+
+type Subscriber = () => void;
+
+const listeners = new Set<Subscriber>();
+const STAGING_POSITION: Vec3 = [0.6, 0.5, -0.2];
+const DEFAULT_ROTATION: Vec3 = [0, 0, 0];
+const DEFAULT_SCALE: Vec3 = [1, 1, 1];
+
+let propsState: GenericProp[] = [];
+let idCounter = 1;
+
+function cloneVec(vec: Vec3): Vec3 {
+  return [vec[0], vec[1], vec[2]];
+}
+
+function emit(next: GenericProp[]) {
+  propsState = next;
+  listeners.forEach((listener) => listener());
+}
+
+function nextId(catalogId: string) {
+  const suffix = idCounter++;
+  return `generic-${catalogId}-${suffix}`;
+}
+
+function updateProp(id: GenericPropId, updater: (current: GenericProp) => GenericProp) {
+  let changed = false;
+  const next = propsState.map((prop) => {
+    if (prop.id !== id) return prop;
+    const updated = updater(prop);
+    if (updated !== prop) {
+      changed = true;
+    }
+    return updated;
+  });
+
+  if (changed) {
+    emit(next);
+  }
+}
+
+function normalizeBlueprint(blueprint: GenericPropBlueprint) {
+  return {
+    catalogId: blueprint.catalogId,
+    label: blueprint.label,
+    url: blueprint.url,
+    anchor: blueprint.anchor,
+    position: blueprint.position ? cloneVec(blueprint.position) : cloneVec(STAGING_POSITION),
+    rotation: blueprint.rotation ? cloneVec(blueprint.rotation) : cloneVec(DEFAULT_ROTATION),
+  };
+}
+
+function normalizeUniformScale(raw: number) {
+  const normalized = Number(raw.toFixed(4));
+  if (!Number.isFinite(normalized) || normalized <= 0) {
+    return 1;
+  }
+  return normalized;
+}
+
+export function spawnGenericProp(blueprint: GenericPropBlueprint): GenericProp {
+  const normalized = normalizeBlueprint(blueprint);
+  const id = nextId(normalized.catalogId);
+
+  const newProp: GenericProp = {
+    id,
+    kind: 'generic',
+    catalogId: normalized.catalogId,
+    label: normalized.label,
+    url: normalized.url,
+    anchor: normalized.anchor,
+    position: normalized.position,
+    rotation: normalized.rotation,
+    scale: cloneVec(DEFAULT_SCALE),
+    status: 'editing',
+  };
+
+  emit([...propsState, newProp]);
+  return newProp;
+}
+
+export function setGenericPropStatus(id: GenericPropId, status: GenericPropStatus) {
+  updateProp(id, (prop) => {
+    if (prop.status === status) {
+      return prop;
+    }
+    return { ...prop, status };
+  });
+}
+
+export function setGenericPropUniformScale(id: GenericPropId, uniformScale: number) {
+  const normalized = normalizeUniformScale(uniformScale);
+  const nextScale: Vec3 = [normalized, normalized, normalized];
+
+  updateProp(id, (prop) => {
+    const [sx, sy, sz] = prop.scale;
+    if (sx === nextScale[0] && sy === nextScale[1] && sz === nextScale[2]) {
+      return prop;
+    }
+    return { ...prop, scale: nextScale };
+  });
+}
+
+export function setGenericPropBounds(id: GenericPropId, bounds: GenericPropBounds) {
+  updateProp(id, (prop) => {
+    const prev = prop.bounds;
+    if (
+      prev &&
+      prev.min[0] === bounds.min[0] &&
+      prev.min[1] === bounds.min[1] &&
+      prev.min[2] === bounds.min[2] &&
+      prev.max[0] === bounds.max[0] &&
+      prev.max[1] === bounds.max[1] &&
+      prev.max[2] === bounds.max[2]
+    ) {
+      return prop;
+    }
+    return { ...prop, bounds };
+  });
+}
+
+export function clearGenericPropBounds(id: GenericPropId) {
+  updateProp(id, (prop) => {
+    if (!prop.bounds) {
+      return prop;
+    }
+    return { ...prop, bounds: undefined };
+  });
+}
+
+export function setGenericPropPosition(id: GenericPropId, position: Vec3) {
+  const nextPosition = cloneVec(position);
+  updateProp(id, (prop) => {
+    const [px, py, pz] = prop.position;
+    if (px === nextPosition[0] && py === nextPosition[1] && pz === nextPosition[2]) {
+      return prop;
+    }
+    return { ...prop, position: nextPosition };
+  });
+}
+
+export function setGenericPropRotation(id: GenericPropId, rotation: Vec3) {
+  const nextRotation = cloneVec(rotation);
+  updateProp(id, (prop) => {
+    const [rx, ry, rz] = prop.rotation;
+    if (rx === nextRotation[0] && ry === nextRotation[1] && rz === nextRotation[2]) {
+      return prop;
+    }
+    return { ...prop, rotation: nextRotation };
+  });
+}
+
+export function getGenericPropsSnapshot(): GenericProp[] {
+  return propsState;
+}
+
+export function getGenericProp(id: GenericPropId): GenericProp | undefined {
+  return propsState.find((prop) => prop.id === id);
+}
+
+export function subscribeGenericProps(listener: Subscriber) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function clearGenericProps() {
+  if (propsState.length === 0) {
+    return;
+  }
+  emit([]);
+}

--- a/apps/web/src/state/genericPropsStore.ts
+++ b/apps/web/src/state/genericPropsStore.ts
@@ -35,7 +35,7 @@ type GenericPropBlueprint = {
 type Subscriber = () => void;
 
 const listeners = new Set<Subscriber>();
-const STAGING_POSITION: Vec3 = [0.6, 0.5, -0.2];
+const STAGING_POSITION: Vec3 = [0.6, 0.05, -0.2];
 const DEFAULT_ROTATION: Vec3 = [0, 0, 0];
 const DEFAULT_SCALE: Vec3 = [1, 1, 1];
 

--- a/apps/web/src/state/genericPropsStore.ts
+++ b/apps/web/src/state/genericPropsStore.ts
@@ -183,6 +183,34 @@ export function setGenericPropRotation(id: GenericPropId, rotation: Vec3) {
   });
 }
 
+function wrapRadians(value: number) {
+  const wrapped = ((value + Math.PI) % (2 * Math.PI) + 2 * Math.PI) % (2 * Math.PI) - Math.PI;
+  return Math.abs(wrapped) < 1e-6 ? 0 : Number(wrapped.toFixed(6));
+}
+
+function radToDeg(rad: number) {
+  return (rad * 180) / Math.PI;
+}
+
+function degToRad(deg: number) {
+  return (deg * Math.PI) / 180;
+}
+
+export function rotateGenericProp(id: GenericPropId, deltaYDeg: number) {
+  updateProp(id, (prop) => {
+    const currentYRad = prop.rotation[1];
+    const deltaYRad = degToRad(deltaYDeg);
+    const nextYRad = wrapRadians(currentYRad + deltaYRad);
+    return { ...prop, rotation: [prop.rotation[0], nextYRad, prop.rotation[2]] };
+  });
+}
+
+export function getGenericPropRotationDeg(id: GenericPropId): number {
+  const prop = getGenericProp(id);
+  if (!prop) return 0;
+  return Number(radToDeg(prop.rotation[1]).toFixed(1));
+}
+
 export function getGenericPropsSnapshot(): GenericProp[] {
   return propsState;
 }

--- a/apps/web/src/state/propScaleStore.ts
+++ b/apps/web/src/state/propScaleStore.ts
@@ -1,0 +1,76 @@
+import type { PropId } from '@/state/propBoundsStore';
+
+export type PropScaleValue = [number, number, number];
+
+export type PropScaleState = Record<PropId, PropScaleValue>;
+
+const DEFAULT_STATE: PropScaleState = {
+  desk: [1, 1, 1],
+  monitor1: [1, 1, 1],
+};
+
+const listeners = new Set<() => void>();
+let state: PropScaleState = cloneState(DEFAULT_STATE);
+let cachedSnapshot: PropScaleState | null = null;
+
+function cloneValue(value: PropScaleValue): PropScaleValue {
+  return [value[0], value[1], value[2]];
+}
+
+function cloneState(source: PropScaleState): PropScaleState {
+  return {
+    desk: cloneValue(source.desk),
+    monitor1: cloneValue(source.monitor1),
+  };
+}
+
+function valuesEqual(a: PropScaleValue, b: PropScaleValue) {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+function notify() {
+  listeners.forEach((listener) => listener());
+}
+
+function setState(next: PropScaleState) {
+  if (!valuesEqual(state.desk, next.desk) || !valuesEqual(state.monitor1, next.monitor1)) {
+    state = next;
+    cachedSnapshot = null;
+    notify();
+  }
+}
+
+export function getPropScaleState(): PropScaleState {
+  if (!cachedSnapshot) {
+    cachedSnapshot = cloneState(state);
+  }
+  return cachedSnapshot;
+}
+
+export function getPropScale(id: PropId): PropScaleValue {
+  return state[id];
+}
+
+export function setPropScale(id: PropId, rawScale: PropScaleValue) {
+  const next = cloneState(state);
+  const current = next[id];
+  if (valuesEqual(current, rawScale)) {
+    return;
+  }
+  next[id] = cloneValue(rawScale);
+  setState(next);
+}
+
+export function setUniformPropScale(id: PropId, scale: number) {
+  setPropScale(id, [scale, scale, scale]);
+}
+
+export function resetPropScales() {
+  setState(cloneState(DEFAULT_STATE));
+}
+
+export function subscribePropScale(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+

--- a/apps/web/src/state/selectionStore.ts
+++ b/apps/web/src/state/selectionStore.ts
@@ -1,0 +1,44 @@
+import type { GenericPropId } from '@/state/genericPropsStore';
+import type { PropId } from '@/state/propBoundsStore';
+
+type DeskSelection = { kind: 'desk'; id: Extract<PropId, 'desk'> };
+type MonitorSelection = { kind: 'monitor'; id: Extract<PropId, 'monitor1'> };
+type GenericSelection = { kind: 'generic'; id: GenericPropId };
+
+export type Selection = DeskSelection | MonitorSelection | GenericSelection | null;
+
+type Subscriber = () => void;
+
+let selectionState: Selection = null;
+const listeners = new Set<Subscriber>();
+
+function equals(a: Selection, b: Selection) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.kind === b.kind && a.id === b.id;
+}
+
+function notify() {
+  listeners.forEach((listener) => listener());
+}
+
+export function getSelection(): Selection {
+  return selectionState;
+}
+
+export function setSelection(next: Selection) {
+  if (equals(selectionState, next)) {
+    return;
+  }
+  selectionState = next;
+  notify();
+}
+
+export function clearSelection() {
+  setSelection(null);
+}
+
+export function subscribeSelection(listener: Subscriber) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/docs/FAILED-SCALING-FIX-ATTEMPTS.md
+++ b/docs/FAILED-SCALING-FIX-ATTEMPTS.md
@@ -1,0 +1,356 @@
+# Failed Attempt: Monitor Scaling Fix (2025-10-02)
+
+## Problem Statement
+When scaling the monitor prop via UI slider, the monitor glitches through the desk surface, moving along a curved path. The position oscillates and is visually broken. Desk scaling works fine; only monitor scaling is affected.
+
+## Root Cause (Confirmed)
+The anchor-point compensation logic in `useAutoLayout.ts` (lines 439-454) creates a feedback loop:
+
+```typescript
+const footDelta = baseFoot && scaledFoot ? scaledFoot.clone().sub(baseFoot) : new THREE.Vector3(0, 0, 0);
+const footLateralOffset = footDelta.dot(frameRight);
+const footDepthOffset = footDelta.dot(frameForward);
+// ...
+lateral: overrides.monitorLateral - footLateralOffset,
+depth: overrides.monitorDepth - footDepthOffset,
+```
+
+**Why this causes oscillation:**
+1. `scaleBoundsFromFoot()` computes scaled bounds from original bounds
+2. Foot position changes → offset calculated
+3. Offset applied to placement → monitor moves
+4. New bounds computed → different foot position → different offset
+5. Cycle repeats → oscillation
+
+**The architectural issue:**
+The GLTFProp transform hierarchy applies scale between anchor translations:
+```
+<group position={position}>        ← Layout-computed position
+  <group position={anchorTuple}>   ← Anchor from ORIGINAL bounds
+    <group scale={scale}>          ← Scale applied here
+      <group position={-anchorTuple}>
+```
+When scale changes, the final world position changes even if `position` is constant, because anchor is from unscaled bounds.
+
+---
+
+## Attempted Fix #1: Detach-Scale-Reattach with Scaling Mode State
+
+### Strategy
+Create a "scaling mode" that:
+1. Freezes monitor placement while user drags slider
+2. Skips layout recomputation during drag
+3. On release, runs one clean solve with final scale
+
+### Implementation
+- Created `scalingModeStore.ts` - state management for active/inactive scaling
+- Created `useScalingMode()` hook
+- Modified `useAutoLayout` to early-return when scaling mode active
+- Modified `PropScaleControls` to enter/exit scaling mode on pointer events
+- Added visual feedback (banner, dimming)
+
+### What Worked ✅
+- Banner "Scaling... release to reattach" appeared correctly
+- Monitor dimmed to 50% opacity during drag
+- Console logging showed state transitions working
+- Scaling mode activation/deactivation worked
+
+### What Failed ❌
+**Problem 1: Monitor still moved while dragging**
+- Even with layout frozen, monitor moved because `monitorScale` prop changed
+- Scale changes → GLTFProp re-renders → anchor system shifts world position
+
+**Fix Attempted:** Freeze scale in SceneRoot
+```typescript
+const monitorScale = scalingMode.active && scalingMode.propId === "monitor1"
+  ? scalingMode.startScale  // ← Use frozen scale
+  : monitorScaleRaw;
+```
+**Result:** Monitor froze during drag ✅ BUT...
+
+**Problem 2: Monitor went to glitchy position on release**
+- When scaling mode exits, `useAutoLayout` runs with the buggy foot-anchor logic
+- Monitor positioned incorrectly (below/above desk on curved path)
+
+### Attempts to Fix Reattachment
+
+#### Attempt 1a: Skip bounds updates during scaling
+Modified GLTFProp to not update bounds while scaling mode active.
+**Result:** Bounds stale on release → placement used wrong bounds
+
+#### Attempt 1b: Use frozen placement from scaling mode
+```typescript
+setLayoutState({
+  ...prevLayout,
+  monitorPlacement: scalingMode.frozenPlacement ?? prevLayout.monitorPlacement,
+});
+```
+**Result:** Still moved because scale was changing, affecting world position through anchor math
+
+#### Attempt 1c: Skip scale dependencies during scaling mode
+```typescript
+// Only depend on scale when NOT in scaling mode
+scalingMode.active && scalingMode.propId === "monitor1" ? null : monitorScaleX,
+```
+**Result:** Reduced re-renders, but didn't fix core positioning issue
+
+---
+
+## Attempted Fix #2: Remove Foot-Anchor Compensation
+
+### Strategy
+Simplify `solveMonitor` call by removing the bloated foot-anchor offset logic entirely.
+
+### Implementation
+Removed lines 431-444 from `useAutoLayout.ts`:
+```typescript
+// REMOVED:
+const frameRight = toVec3(frame.right);
+const frameForward = toVec3(frame.forward);
+const monitorScaleVec = [monitorScaleX, monitorScaleY, monitorScaleZ];
+const baseMonitorBounds = initialMonitorBoundsRef.current;
+const scaledMonitorBounds = baseMonitorBounds && hasNonUnitScale(monitorScaleVec)
+  ? scaleBoundsFromFoot(baseMonitorBounds, monitorScaleVec)
+  : baseMonitorBounds;
+const baseFoot = initialMonitorFootRef.current ?? ...;
+const scaledFoot = scaledMonitorBounds ? boundsBottomCenter(scaledMonitorBounds) : baseFoot;
+const footDelta = baseFoot && scaledFoot ? scaledFoot.clone().sub(baseFoot) : ...;
+const footLateralOffset = footDelta.dot(frameRight);
+const footDepthOffset = footDelta.dot(frameForward);
+```
+
+Changed `solveMonitor` call to:
+```typescript
+solveMonitor(
+  frame,
+  deskSurface,
+  monitorMeta,
+  monitorBounds ?? null,
+  initialMonitorMetaRef.current,
+  null, // ← baseBounds set to null
+  { lateral: overrides.monitorLateral, depth: overrides.monitorDepth },
+  null, // ← scaledBounds set to null
+);
+```
+
+### What Failed ❌
+**CRITICAL FAILURE - Scene broke on load**
+- Monitor oscillated rapidly between two positions on initial render
+- When scaling attempted, monitor position coordinates ballooned to 10000x
+- Monitor started rotating in circles
+- Entire scene became unusable
+
+**Root cause of failure:**
+By setting `baseBounds: null`, the fallback logic in `solveMonitor` broke:
+```typescript
+const referenceBounds = scaledBounds ?? baseBounds ?? currentBounds;
+if (!referenceBounds && !baseMeta) {
+  return null; // ← Placement became null
+}
+```
+During initial load, `currentBounds` is `null` (GLTFProp hasn't computed it yet), so placement returned `null`, causing chaos.
+
+**Lesson:** The `baseBounds` fallback is a **critical safety net** for initial render. Cannot be removed without replacement.
+
+---
+
+## Key Insights for Future Attempts
+
+### What We Confirmed
+1. **The foot-anchor compensation IS the problem** - Not just a theory, confirmed through testing
+2. **Detach-while-scaling DOES work** - Visual freeze was successful
+3. **The reattachment uses the buggy logic** - That's why release fails
+4. **baseBounds cannot be null** - It's required for initial render
+
+### What We Don't Know Yet
+1. **Why does desk scaling work?**
+   - Desk is the reference frame itself, so maybe different code path?
+   - Or desk doesn't use foot-anchor compensation?
+   - Need to trace desk scaling flow vs monitor scaling flow
+
+2. **What is `scaleBoundsFromFoot()` trying to achieve?**
+   - Preserves foot position, but why?
+   - Is this for stand alignment (future feature mentioned in docs)?
+   - Can we compute this differently?
+
+3. **Can we change the anchor system?**
+   - What if anchor was based on scaled bounds instead of original?
+   - Would this break other props (desk, future keyboard/lamp)?
+
+### Architecture Constraints Discovered
+
+**GLTFProp Transform Hierarchy:**
+```
+Outer group: position (from layout) + rotation
+  ↓
+  Anchor translation (from ORIGINAL bounds)
+    ↓
+    Scale group (scale applied here)
+      ↓
+      Negative anchor translation
+        ↓
+        GLTF scene
+```
+
+**Key issue:** Anchor is computed once from original (unscaled) scene bounds. When scale changes, anchor stays the same, so effective world position shifts.
+
+**Example:**
+- Original monitor height: 0.5m, anchor at bottom (y=0.25m)
+- Scale to 1.5x → monitor is now 0.75m tall
+- But anchor still at y=0.25m (from original)
+- So bottom of monitor is now at `position.y + 0.25m - (0.25m * 1.5) = position.y - 0.125m`
+- The monitor "sinks" by 0.125m even though `position` didn't change
+
+### Potential Solutions (Untried)
+
+#### Option A: Scale-Aware Anchors
+Modify GLTFProp to recompute anchor when scale changes.
+
+**Pros:**
+- Fixes root cause
+- Benefits all future props
+
+**Cons:**
+- Changes core prop system
+- Might break existing desk behavior
+- Unknown edge cases
+
+**Implementation sketch:**
+```typescript
+const anchorVector = React.useMemo(() => {
+  const baseAnchor = computeAnchor(scene, anchor);
+  if (!baseAnchor || !Array.isArray(scale)) return baseAnchor;
+  // Scale the anchor offset itself
+  return new THREE.Vector3(
+    baseAnchor.x * scale[0],
+    baseAnchor.y * scale[1],
+    baseAnchor.z * scale[2]
+  );
+}, [scene, anchor, scale]);
+```
+
+#### Option B: Placement-Time Scale Compensation
+In `solveMonitor`, compute placement that accounts for anchor shift.
+
+**Pros:**
+- Isolated to monitor placement logic
+- Doesn't touch GLTFProp
+
+**Cons:**
+- Complex math (compensating for compensation)
+- Might just recreate the current buggy logic
+
+**Implementation sketch:**
+```typescript
+// After computing lift/lateral/depth
+// Add correction for anchor shift due to scale
+const scaleVec = getCurrentScale(); // Need to pass this in
+const anchorShiftY = originalAnchor.y * (scaleVec[1] - 1);
+liftDelta += anchorShiftY;
+```
+
+#### Option C: Two-Pass Approach
+1. Scale the monitor (bounds update)
+2. Wait one frame
+3. Run placement solve with updated bounds
+
+**Pros:**
+- Uses actual scaled bounds, not computed ones
+- Avoids math errors
+
+**Cons:**
+- Timing-dependent
+- Visual "pop" on frame 2
+- Fragile if render timing changes
+
+**Implementation sketch:**
+```typescript
+const [pendingScale, setPendingScale] = useState(null);
+
+useEffect(() => {
+  if (pendingScale && monitorBounds) {
+    // Bounds have updated, now solve placement
+    runPlacementSolve();
+    setPendingScale(null);
+  }
+}, [pendingScale, monitorBounds]);
+```
+
+#### Option D: Remove Scaling Feature for Monitor
+Simplest solution: Only allow desk scaling, disable monitor scaling UI.
+
+**Pros:**
+- No code changes needed
+- Avoids entire problem
+
+**Cons:**
+- Reduces functionality
+- User expectation mismatch (why can desk scale but not monitor?)
+
+---
+
+## What NOT to Try Again
+
+### ❌ Setting baseBounds to null
+**Why it fails:** Breaks initial render fallback logic. Placement becomes null → chaos.
+
+### ❌ Using scaledBounds computed from original bounds
+**Why it fails:** `scaleBoundsFromFoot()` math doesn't match actual anchor behavior.
+
+### ❌ Freezing placement without freezing scale
+**Why it fails:** Scale changes shift world position through anchor system.
+
+### ❌ Complex dependency array tricks in useAutoLayout
+**Why it fails:** Doesn't address root cause, just masks symptoms. Still uses buggy logic on release.
+
+---
+
+## Recommended Next Steps
+
+1. **Understand desk scaling** - Why does it work? Trace the code path. Might reveal why monitor is different.
+
+2. **Test Option A (scale-aware anchors)** - Most likely to succeed, but requires careful testing of desk behavior.
+
+3. **Profile the math** - Create a standalone test that shows:
+   - Original position at scale 1.0
+   - Expected position at scale 1.5
+   - Actual position at scale 1.5
+   - What the current code computes
+   - What it should compute
+
+4. **Consider if this is worth fixing** - Is monitor scaling critical? Or can we ship without it?
+
+---
+
+## Files Modified During Failed Attempt
+
+**Created (now deleted):**
+- `apps/web/src/state/scalingModeStore.ts`
+- `apps/web/src/canvas/hooks/useScalingMode.ts`
+
+**Modified (reverted):**
+- `apps/web/src/canvas/hooks/useAutoLayout.ts`
+- `apps/web/src/app/canvas/SceneRoot.tsx`
+- `apps/web/src/canvas/props/GLTFProp.tsx`
+- `apps/web/src/canvas/props/MonitorProp.tsx`
+- `apps/web/src/canvas/PropScaleControls.tsx`
+
+All changes reverted via `git checkout`.
+
+---
+
+## Time Investment
+Approximately 4-5 hours of development + debugging.
+
+**Wins:**
+- Confirmed root cause
+- Proved detach-while-scaling works
+- Identified architectural constraints
+- Ruled out several dead ends
+
+**Losses:**
+- No working fix
+- Scaling still broken
+- User feature not delivered
+
+**Net result:** Better understanding of problem, but no solution. Future attempts should focus on Option A (scale-aware anchors) or Option D (disable feature).


### PR DESCRIPTION
- Set up a separate genericPropsStore, selection store, and rendering layer so free props can spawn, scale,
  and drag without disturbing desk/monitor auto-layout.
  - Reused the desk/monitor scale UI by routing it through the new selection store; added a bottom editing
  banner and made the scale panel auto-open when a prop is spawned.
  - Implemented world dragging with plane projection, pointer capture, and an orbit-lock guard so camera
  motion doesn’t interfere. Added a teal ring highlight to make selection obvious.
  - Added a desk-clearance clamp during dragging and ESC-to-exit support (which now clears selection) so props
  never sink into the surface and drag mode cancels gracefully.

Fixed height placement of added props. Props can now rotate.